### PR TITLE
Add default branch to config

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ Useful when migrating from Snap CI to Concourse CI.
 
 * `repository`: *Required.* The Snap CI build repository.
 
-* `branch_name`: *Required.* The Snap CI build branch name.
-
 * `user`: *Required.* Your Snap CI user account.
 
 * `api_key`: *Required.* Your Snap CI User API Key.
 
 * `result_filter`: *Optional.* Only list pipelines that match this result.
+
+* `branch_name`: *Optional.* The Snap CI build branch name. Defaults to `master`.
 
 ## Behavior
 

--- a/bin/check
+++ b/bin/check
@@ -20,7 +20,7 @@ cat > $payload <&0
 
 owner=$(jq -r '.source.owner // ""' < $payload)
 repository=$(jq -r '.source.repository // ""' < $payload)
-branch_name=$(jq -r '.source.branch_name // ""' < $payload)
+branch_name=$(jq -r '.source.branch_name // "master"' < $payload)
 user=$(jq -r '.source.user // ""' < $payload)
 api_key=$(jq -r '.source.api_key // ""' < $payload)
 


### PR DESCRIPTION
Made `master` default value for `branch_name` if none specified in source JSON object.